### PR TITLE
HPCC-27791 - Create confidence tests and key files for the DbScan bundle

### DIFF
--- a/OBTTests/ecl/AccuracyTestModified.ecl
+++ b/OBTTests/ecl/AccuracyTestModified.ecl
@@ -1,0 +1,94 @@
+/*##############################################################################
+    
+    HPCC SYSTEMS software Copyright (C) 2022 HPCC Systems®.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+       
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+// Modified version of the Accuracy test file that is 
+// compatible with the OBT test system
+
+IMPORT ML_Core;
+IMPORT DBSCAN;
+IMPORT DBSCAN.tests.datasets.frogDS_Small AS frog_data;
+IMPORT DBSCAN.tests.datasets.blobsDS AS blobsDS;
+
+/*
+ * This test compares the results of HPCC DBSCAN against
+ * sklearn's DBSCAN implementation on frogDS_Small dataset
+ * using Euclidean distance metric.
+ */
+
+// Load frog_data
+ds := frog_data.ds;
+
+// Convert to NumericField
+ML_Core.AppendSeqID(ds,id,dsID);
+ML_Core.ToField(dsID,dsNF);
+
+// Produce clustering result
+clustering := DBSCAN.DBSCAN(0.3,10).fit(dsNF);
+
+// Compare with sklearn results
+sk_res := frog_data.sklearn_results;
+
+// Append an id field to sk_res
+ML_Core.AppendSeqID(sk_res,id,sk_res_id);
+
+
+// Find rows that do not match the sklearn result
+no_match := JOIN(clustering, sk_res_id,
+                 LEFT.id=RIGHT.id and LEFT.label <> RIGHT.a+1,
+                 TRANSFORM({ML_Core.Types.ClusterLabels,INTEGER sklabel},
+                           SELF.sklabel := RIGHT.a,
+                           SELF := LEFT));
+                           
+
+// Test number of rows, allows for slight mismatch
+OUTPUT(IF(COUNT(no_match) < 2, 'Pass',  'Fail: ' + COUNT(no_match) + ' Rows'), NAMED('Test1'));
+
+
+/*
+ * This test compares the results of HPCC DBSCAN against
+ * sklearn's DBSCAN implementation on blobsDS dataset
+ * using Chebyshev distance metric.
+ */
+
+// Load blobsDS dataset
+blobs := blobsDS.trainRec;
+
+// Convert to NumericField
+ML_Core.ToField(blobs,recs);
+
+// Training set (Independent Var)
+trainNF := recs(number < 3);
+// Testing set (Dependent Var)
+testNF := recs(number = 3);
+
+// Produce clustering result
+mod := DBSCAN.DBSCAN(0.3, 2, dist := 'chebyshev').fit(trainNF);
+
+// Accuracy test : The result shows the accuracy of our results compared to SK_learn results.
+accuracy := JOIN(mod, testNF,
+            LEFT.wi = RIGHT.wi
+            AND
+            LEFT.id = RIGHT.id,
+            TRANSFORM({UNSIGNED4 id, INTEGER ecl, INTEGER sk, BOOLEAN same},
+                      SELF.same := IF(LEFT.label = (RIGHT.value + 1), TRUE, FALSE),
+                      SELF.ecl := LEFT.label,
+                      SELF.sk := RIGHT.value,
+                      SELF := LEFT));
+
+// The same field should be true for each row (value of ecl = sk + 1)
+NumDiffRows := COUNT(accuracy(same = FALSE));
+OUTPUT(IF(NumDiffRows = 0, 'Pass', 'Fail: ' + NumDiffRows + ' Different Rows'), NAMED('Test2'));

--- a/OBTTests/ecl/MergeTest.ecl
+++ b/OBTTests/ecl/MergeTest.ecl
@@ -1,0 +1,53 @@
+/*##############################################################################
+    
+    HPCC SYSTEMS software Copyright (C) 2022 HPCC Systems®.
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+       
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+############################################################################## */
+
+#ONWARNING(4550, ignore);
+
+// Tests the merge function from globalMerge.ecl
+
+IMPORT DBSCAN;
+IMPORT DBSCAN.Internal;
+IMPORT DBSCAN.DBSCAN_Types;
+
+MergeType := DBSCAN_Types.l_stage3;
+
+Input1 := DATASET([{ 1, 2, 3, 4},  {1, 5, 3, 4}], MergeType);
+
+Result1 := Internal.globalMerge.merge(Input1);
+NumRows1 := COUNT(Result1);
+Expected1 := 1;
+
+// Both rows of the input have the same wi and id so there should only be one row
+OUTPUT(IF(NumRows1 = Expected1, 'Pass', 'Fail: ' + NumRows1 + ' Rows'), NAMED('Test1'));
+
+
+Input2 := DATASET([{ 1, 2, 3, 4}, {5, 2, 5, 2}, {5, 1, 5, 3}, {8, 2, 8, 4}], MergeType);
+
+Result2 := Internal.globalMerge.merge(Input2);
+NumRows2 := COUNT(Result2);
+Expected2 := 3;
+
+// Two Rows merge, leaving 3 rows
+OUTPUT(IF(NumRows2 = Expected2, 'Pass', 'Fail: ' + NumRows2 + ' Rows'), NAMED('Test2'));
+
+
+Input3 := DATASET([{6, 2, 8, 2}, {6, 1, 7, 3}], MergeType);
+
+Result3 := Internal.globalMerge.merge(Input3);
+
+// Since Result3[2] has a lower id value than Result3[1], it should have the lower label value
+OUTPUT(IF(Result3[1].label > Result3[2].label, 'Pass', 'Fail'), NAMED('Test3'));

--- a/OBTTests/ecl/key/AccuracyTestModified.xml
+++ b/OBTTests/ecl/key/AccuracyTestModified.xml
@@ -1,0 +1,6 @@
+<Dataset name='Test1'>
+ <Row><Test1>Pass</Test1></Row>
+</Dataset>
+<Dataset name='Test2'>
+ <Row><Test2>Pass</Test2></Row>
+</Dataset>

--- a/OBTTests/ecl/key/MergeTest.xml
+++ b/OBTTests/ecl/key/MergeTest.xml
@@ -1,0 +1,9 @@
+<Dataset name='Test1'>
+ <Row><Test1>Pass</Test1></Row>
+</Dataset>
+<Dataset name='Test2'>
+ <Row><Test2>Pass</Test2></Row>
+</Dataset>
+<Dataset name='Test3'>
+ <Row><Test3>Pass</Test3></Row>
+</Dataset>


### PR DESCRIPTION
- Create ecl and key folder
- Update test code from the tests folder to be compatible with the OBT system alongside other changes 
- Create a key file for each test, displaying the passing output in XML format